### PR TITLE
Fix typo in config file template

### DIFF
--- a/config.py
+++ b/config.py
@@ -9,4 +9,4 @@ trigger = '/u/PersonalityInsights'
 # Watson API
 watsonUrl = 'https://gateway.watsonplatform.net/personality-insights/api/v3/profile?version=2017-10-13'
 usernameWatson = ''
-passwordWatson
+passwordWatson = ''


### PR DESCRIPTION
This config file template does not work because line 12 is not defined correctly.